### PR TITLE
Remove extending ContainerAware

### DIFF
--- a/HDFS/HDFSClient.php
+++ b/HDFS/HDFSClient.php
@@ -3,12 +3,11 @@
 namespace jimbglenn\webHDFSClientBundle\HDFS;
 
 use jimbglenn\webHDFSClientBundle\HDFS\Curl as Curl;
-use Symfony\Component\DependencyInjection\ContainerAware;
 
 /**
  * Class HDFSClient
  */
-class HDFSClient extends ContainerAware
+class HDFSClient
 {
 
     private $serverName;


### PR DESCRIPTION
Usage is deprecated Symfony 2.8 and removed in Symfony 3