### PR TITLE
Remove exception in constructor.

### DIFF
--- a/HDFS/HDFSClient.php
+++ b/HDFS/HDFSClient.php
@@ -23,14 +23,9 @@ class HDFSClient
      */
     public function __construct($serverName = null, $port = null, $user = null)
     {
-
         $this->serverName = $serverName;
         $this->port = $port;
         $this->user = $user;
-
-        if (!$this->isHDFSOnline()) {
-            throw new \RuntimeException("Could not connect to HDFS");
-        }
     }
 
     /**


### PR DESCRIPTION
Prevents dependency injection from occurring. We can still check if HDFS exists with the method in the client and still inject the service without getting errors that it cannot connect to HDFS